### PR TITLE
🔤 Perform case-insensitive matching

### DIFF
--- a/passrofi
+++ b/passrofi
@@ -4,7 +4,7 @@ export prefix=${PASSWORD_STORE_DIR-~/.password-store}
 
 account="$(find "$prefix" -type f -name '*.gpg' -print0 | \
     xargs -I '{}' -0 sh -c 'f="{}"; f="${f#"$prefix"/}"; echo "${f%.gpg}"' | \
-    rofi -dmenu -p "Accounts:" -kb-custom-1 "Ctrl+i" -kb-custom-2 "Ctrl+o")"
+    rofi -dmenu -i -p "Accounts:" -kb-custom-1 "Ctrl+i" -kb-custom-2 "Ctrl+o")"
 retv=$?
 
 if [ $retv -eq 10 ]


### PR DESCRIPTION
The Merge Request makes `rofi` do case-insensitive matching, which is probably what everyone wants.